### PR TITLE
Fix Tailwind purge paths for FSE HTML templates

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,12 @@
 module.exports = {
-content: [
-  "./*.php",
-  "./template-parts/**/*.php",
-  "./block-patterns/**/*.php",
-  "./assets/js/**/*.js"
-],
+  content: [
+    "./*.php",
+    "./templates/**/*.html",
+    "./parts/**/*.html",
+    "./template-parts/**/*.php",
+    "./block-patterns/**/*.php",
+    "./assets/js/**/*.js",
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- include HTML templates and parts in Tailwind `content` array

## Testing
- `npm run build` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f907cc888325913ca1cc6486157c